### PR TITLE
feat: populate real CV content and match CV color palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sascha Hurle — Portfolio</title>
   <meta name="author" content="Sascha Hurle">
-  <meta name="description" content="Portfolio of Sascha Hurle — Product Owner & Digital Strategist">
+  <meta name="description" content="Portfolio of Sascha Hurle — Product Owner in Finance & Media">
   <link rel="stylesheet" href="style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -22,6 +22,7 @@
         <li><a href="#experience">Experience</a></li>
         <li><a href="#projects">Projects</a></li>
         <li><a href="#skills">Skills</a></li>
+        <li><a href="#education">Education</a></li>
         <li><a href="#contact" class="nav-cta">Contact</a></li>
       </ul>
       <button class="nav-toggle" aria-label="Toggle menu">
@@ -37,6 +38,7 @@
       <li><a href="#experience">Experience</a></li>
       <li><a href="#projects">Projects</a></li>
       <li><a href="#skills">Skills</a></li>
+      <li><a href="#education">Education</a></li>
       <li><a href="#contact">Contact</a></li>
     </ul>
   </div>
@@ -51,15 +53,14 @@
     <div class="hero-content">
       <div class="hero-badge reveal">
         <span class="badge-dot"></span>
-        Available for new projects
+        Open to new opportunities
       </div>
       <h1 class="hero-title reveal">
         <span class="hero-name">Sascha Hurle</span>
-        <span class="hero-role">Product Owner <br class="hero-br">&amp; Digital Strategist</span>
+        <span class="hero-role">Product Owner in <br class="hero-br">Finance &amp; Media</span>
       </h1>
       <p class="hero-desc reveal">
-        Bridging the gap between users, business goals, and engineering teams.
-        Turning complex problems into clear, shippable solutions.
+        Strategic, technical product owner with 8+ years of experience building scalable, modular software. Expert in product strategy and cross-functional leadership for complex solutions.
       </p>
       <div class="hero-actions reveal">
         <a href="#projects" class="btn btn-primary">View My Work</a>
@@ -80,19 +81,19 @@
           <p class="section-label">About me</p>
           <h2 class="section-title">Turning vision into <em>reality</em></h2>
           <p class="about-body">
-            I'm a Product Owner based in Germany with years of experience leading cross-functional teams at companies like SWR and TeraVolt. I thrive at the intersection of user needs, technical constraints, and business strategy.
+            I'm a Product Owner based in Hamburg with 8+ years of experience building scalable, modular software products. I've led cross-functional teams across the finance and media industries — from modular trading platforms at financial.com to news apps at Südwestrundfunk.
           </p>
           <p class="about-body">
-            Currently motivated to expand my skill set into software development — because the best product owners understand how the product is actually built.
+            I thrive at the intersection of user needs, technical constraints, and business strategy — and I'm actively expanding my engineering skills to become an even more effective PO.
           </p>
           <div class="about-stats">
             <div class="stat">
-              <span class="stat-number">5+</span>
+              <span class="stat-number">8+</span>
               <span class="stat-label">Years as PO</span>
             </div>
             <div class="stat">
-              <span class="stat-number">10+</span>
-              <span class="stat-label">Products shipped</span>
+              <span class="stat-number">12+</span>
+              <span class="stat-label">Engineers led</span>
             </div>
             <div class="stat">
               <span class="stat-number">3</span>
@@ -106,13 +107,14 @@
               <div class="avatar-placeholder">SH</div>
             </div>
             <h3>Sascha Hurle</h3>
-            <p>Product Owner &amp; PO</p>
+            <p>Product Owner</p>
+            <p class="card-location">📍 Hamburg, Germany</p>
             <div class="card-tags">
+              <span class="tag">Finance</span>
+              <span class="tag">Media</span>
               <span class="tag">Agile</span>
               <span class="tag">Scrum</span>
-              <span class="tag">Roadmaps</span>
-              <span class="tag">User Stories</span>
-              <span class="tag">OKRs</span>
+              <span class="tag">CSPO</span>
             </div>
           </div>
         </div>
@@ -133,18 +135,21 @@
             <div class="timeline-header">
               <div>
                 <h3 class="timeline-role">Product Owner</h3>
-                <span class="timeline-company">SWR — Südwestrundfunk</span>
+                <span class="timeline-company">financial.com</span>
               </div>
-              <span class="timeline-date">Jun 2021 — Present</span>
+              <span class="timeline-date">2023 — Present</span>
             </div>
-            <p class="timeline-desc">
-              Leading product discovery and delivery for digital media products. Managing the backlog, facilitating sprint ceremonies, and aligning stakeholders across editorial and engineering teams.
-            </p>
+            <ul class="timeline-list">
+              <li>Led product vision and execution for a modular trading platform</li>
+              <li>Zero-to-one broker development incl. account opening process based on compliance and KYC/AML regulations</li>
+              <li>Developed core trading engine components (via FIX protocol) supporting multi-venue connectivity</li>
+              <li>Managed cross-functional teams of 12+ engineers, QA, UX, and compliance specialists to deliver monthly feature releases</li>
+            </ul>
             <div class="timeline-tags">
-              <span class="tag tag-sm">Scrum</span>
-              <span class="tag tag-sm">Jira</span>
-              <span class="tag tag-sm">Confluence</span>
-              <span class="tag tag-sm">Product Strategy</span>
+              <span class="tag tag-sm">Trading Platforms</span>
+              <span class="tag tag-sm">FIX Protocol</span>
+              <span class="tag tag-sm">Compliance</span>
+              <span class="tag tag-sm">FinTech</span>
             </div>
           </div>
         </div>
@@ -154,18 +159,44 @@
           <div class="timeline-content">
             <div class="timeline-header">
               <div>
-                <h3 class="timeline-role">PM / Product Owner</h3>
-                <span class="timeline-company">TeraVolt</span>
+                <h3 class="timeline-role">Product Owner</h3>
+                <span class="timeline-company">Südwestrundfunk (SWR)</span>
               </div>
-              <span class="timeline-date">Apr 2018 — May 2021</span>
+              <span class="timeline-date">2020 — 2023</span>
             </div>
-            <p class="timeline-desc">
-              Managed digital products from ideation to launch. Collaborated closely with UX designers and software engineers to define requirements and deliver high-quality features on time.
-            </p>
+            <ul class="timeline-list">
+              <li>Revamped and modernized the SWR News app (SWR Aktuell App)</li>
+              <li>Introduced Flutter as cross-platform development framework to reduce costs &amp; time to market</li>
+            </ul>
             <div class="timeline-tags">
-              <span class="tag tag-sm">Roadmapping</span>
-              <span class="tag tag-sm">Stakeholder Mgmt</span>
-              <span class="tag tag-sm">Agile</span>
+              <span class="tag tag-sm">Flutter</span>
+              <span class="tag tag-sm">Mobile</span>
+              <span class="tag tag-sm">Media</span>
+              <span class="tag tag-sm">News Apps</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="timeline-item reveal">
+          <div class="timeline-dot"></div>
+          <div class="timeline-content">
+            <div class="timeline-header">
+              <div>
+                <h3 class="timeline-role">Product Owner</h3>
+                <span class="timeline-company">TeraVolt GmbH</span>
+              </div>
+              <span class="timeline-date">2018 — 2020</span>
+            </div>
+            <ul class="timeline-list">
+              <li>Bootstrapped a scalable SaaS platform (TV App) delivered as mobile &amp; web SDK in cooperation with the Bundesliga (DFL) Interactive Feed</li>
+              <li>Production agreements for various customer projects with the German TV market</li>
+              <li>Consultant &amp; Project Management for Sky Germany's new CMS tool</li>
+            </ul>
+            <div class="timeline-tags">
+              <span class="tag tag-sm">SaaS</span>
+              <span class="tag tag-sm">SDK</span>
+              <span class="tag tag-sm">Bundesliga / DFL</span>
+              <span class="tag tag-sm">Sky Germany</span>
             </div>
           </div>
         </div>
@@ -182,49 +213,52 @@
       <div class="projects-grid">
 
         <div class="project-card reveal">
-          <div class="project-accent" style="--accent: #6366f1;"></div>
+          <div class="project-accent" style="--accent: #c8a84a;"></div>
           <div class="project-body">
-            <div class="project-icon">📺</div>
-            <h3 class="project-title">SWR Media Platform</h3>
+            <div class="project-icon">📈</div>
+            <h3 class="project-title">Modular Trading Platform</h3>
             <p class="project-desc">
-              Owned the product strategy for a multi-platform media distribution service reaching millions of users. Led discovery, prioritization, and delivery over multiple release cycles.
+              Led zero-to-one development of a broker platform at financial.com — covering account opening, compliance flows, and a FIX-protocol trading engine supporting multi-venue connectivity.
             </p>
             <div class="project-tags">
-              <span class="tag tag-sm">Product Strategy</span>
-              <span class="tag tag-sm">Media</span>
+              <span class="tag tag-sm">FinTech</span>
+              <span class="tag tag-sm">FIX Protocol</span>
+              <span class="tag tag-sm">Compliance</span>
               <span class="tag tag-sm">B2C</span>
             </div>
           </div>
         </div>
 
         <div class="project-card reveal">
-          <div class="project-accent" style="--accent: #ec4899;"></div>
+          <div class="project-accent" style="--accent: #a07828;"></div>
           <div class="project-body">
-            <div class="project-icon">⚡</div>
-            <h3 class="project-title">TeraVolt Dashboard</h3>
+            <div class="project-icon">📰</div>
+            <h3 class="project-title">SWR Aktuell App</h3>
             <p class="project-desc">
-              Defined and shipped an internal analytics dashboard used by operations and marketing teams to monitor KPIs in real time. Reduced reporting time by 60%.
+              Revamped the SWR News app from the ground up. Introduced Flutter as a cross-platform framework, significantly reducing development costs and time-to-market for new features.
             </p>
             <div class="project-tags">
-              <span class="tag tag-sm">B2B SaaS</span>
-              <span class="tag tag-sm">Analytics</span>
-              <span class="tag tag-sm">Internal Tools</span>
+              <span class="tag tag-sm">Flutter</span>
+              <span class="tag tag-sm">Mobile</span>
+              <span class="tag tag-sm">News</span>
+              <span class="tag tag-sm">Public Media</span>
             </div>
           </div>
         </div>
 
         <div class="project-card reveal">
-          <div class="project-accent" style="--accent: #10b981;"></div>
+          <div class="project-accent" style="--accent: #e2c97e;"></div>
           <div class="project-body">
-            <div class="project-icon">🌐</div>
-            <h3 class="project-title">Portfolio Website</h3>
+            <div class="project-icon">🏆</div>
+            <h3 class="project-title">DFL Interactive Feed SDK</h3>
             <p class="project-desc">
-              Built this portfolio from scratch as part of my journey into software development — writing real HTML, CSS, and JavaScript to understand how products are engineered under the hood.
+              Bootstrapped a SaaS TV app platform delivered as a mobile &amp; web SDK in partnership with the Bundesliga (DFL). Delivered production projects for the German TV market including Sky Germany.
             </p>
             <div class="project-tags">
-              <span class="tag tag-sm">HTML</span>
-              <span class="tag tag-sm">CSS</span>
-              <span class="tag tag-sm">JavaScript</span>
+              <span class="tag tag-sm">SaaS</span>
+              <span class="tag tag-sm">SDK</span>
+              <span class="tag tag-sm">Bundesliga</span>
+              <span class="tag tag-sm">Broadcast</span>
             </div>
           </div>
         </div>
@@ -248,55 +282,99 @@
           <div class="skill-tags">
             <span class="tag">Product Strategy</span>
             <span class="tag">Roadmapping</span>
-            <span class="tag">User Research</span>
-            <span class="tag">A/B Testing</span>
-            <span class="tag">OKRs &amp; KPIs</span>
+            <span class="tag">Agile Methods</span>
             <span class="tag">Backlog Refinement</span>
             <span class="tag">Sprint Planning</span>
-          </div>
-        </div>
-
-        <div class="skill-group reveal">
-          <h3 class="skill-group-title">
-            <span class="skill-group-icon">🤝</span>
-            Leadership &amp; Process
-          </h3>
-          <div class="skill-tags">
-            <span class="tag">Stakeholder Management</span>
-            <span class="tag">Scrum</span>
-            <span class="tag">Kanban</span>
-            <span class="tag">Cross-functional Teams</span>
-            <span class="tag">Workshop Facilitation</span>
+            <span class="tag">Trading Platforms</span>
           </div>
         </div>
 
         <div class="skill-group reveal">
           <h3 class="skill-group-title">
             <span class="skill-group-icon">🛠️</span>
-            Tools &amp; Tech
+            Tools
           </h3>
           <div class="skill-tags">
             <span class="tag">Jira</span>
             <span class="tag">Confluence</span>
             <span class="tag">Figma</span>
-            <span class="tag">HTML &amp; CSS</span>
-            <span class="tag">Git</span>
-            <span class="tag">SQL (learning)</span>
-            <span class="tag">JavaScript (learning)</span>
+            <span class="tag">AI Tooling</span>
           </div>
         </div>
 
         <div class="skill-group reveal">
           <h3 class="skill-group-title">
-            <span class="skill-group-icon">💬</span>
-            Soft Skills
+            <span class="skill-group-icon">💻</span>
+            Tech &amp; Development
           </h3>
           <div class="skill-tags">
-            <span class="tag">Communication</span>
-            <span class="tag">Empathy</span>
-            <span class="tag">Problem Solving</span>
-            <span class="tag">Storytelling</span>
-            <span class="tag">Adaptability</span>
+            <span class="tag">HTML &amp; CSS</span>
+            <span class="tag">JavaScript</span>
+            <span class="tag">Git</span>
+            <span class="tag">FIX Protocol</span>
+            <span class="tag">Flutter (overview)</span>
+          </div>
+        </div>
+
+        <div class="skill-group reveal">
+          <h3 class="skill-group-title">
+            <span class="skill-group-icon">🤝</span>
+            Leadership
+          </h3>
+          <div class="skill-tags">
+            <span class="tag">Cross-functional Teams</span>
+            <span class="tag">Stakeholder Management</span>
+            <span class="tag">Scrum</span>
+            <span class="tag">Compliance &amp; KYC</span>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- Education & Certificates -->
+  <section class="section" id="education">
+    <div class="container">
+      <p class="section-label reveal">Background</p>
+      <h2 class="section-title reveal">Education &amp; Certificates</h2>
+      <div class="edu-grid">
+
+        <div class="edu-col reveal">
+          <h3 class="edu-col-title">
+            <span class="edu-col-icon">🎓</span> Education
+          </h3>
+          <div class="edu-list">
+            <div class="edu-item">
+              <div class="edu-degree">M.A. — Business &amp; Management</div>
+              <div class="edu-school">FH — Sport Economics</div>
+              <div class="edu-year">2016</div>
+            </div>
+            <div class="edu-item">
+              <div class="edu-degree">B.Sc. — Business Administration</div>
+              <div class="edu-school">LMU Munich</div>
+              <div class="edu-year">2014</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="edu-col reveal">
+          <h3 class="edu-col-title">
+            <span class="edu-col-icon">📜</span> Certificates
+          </h3>
+          <div class="edu-list">
+            <div class="edu-item">
+              <div class="edu-degree">Certified Scrum Product Owner</div>
+              <div class="edu-school">CSPO</div>
+            </div>
+            <div class="edu-item">
+              <div class="edu-degree">Frontend Coding Bootcamp</div>
+              <div class="edu-school">Web Development</div>
+            </div>
+            <div class="edu-item">
+              <div class="edu-degree">Product Management Leadership Program</div>
+              <div class="edu-school">Leadership &amp; Strategy</div>
+            </div>
           </div>
         </div>
 
@@ -305,7 +383,7 @@
   </section>
 
   <!-- Contact -->
-  <section class="section" id="contact">
+  <section class="section section-alt" id="contact">
     <div class="container">
       <div class="contact-wrapper reveal">
         <p class="section-label">Get in touch</p>
@@ -314,11 +392,18 @@
           Whether you have a product challenge, want to collaborate, or just want to say hi — my inbox is open.
         </p>
         <div class="contact-links">
-          <a href="mailto:sascha.hurle@diesdas.com" class="contact-link">
+          <a href="mailto:sascha.hurle@gmail.com" class="contact-link">
             <span class="contact-link-icon">✉️</span>
             <div>
               <span class="contact-link-label">Email</span>
-              <span class="contact-link-value">sascha.hurle@diesdas.com</span>
+              <span class="contact-link-value">sascha.hurle@gmail.com</span>
+            </div>
+          </a>
+          <a href="tel:+4915154414511" class="contact-link">
+            <span class="contact-link-icon">📞</span>
+            <div>
+              <span class="contact-link-label">Phone</span>
+              <span class="contact-link-value">+49 151 544 145 11</span>
             </div>
           </a>
           <a href="https://twitter.com/komm_klar_" class="contact-link" target="_blank" rel="noopener">
@@ -328,15 +413,15 @@
               <span class="contact-link-value">@komm_klar_</span>
             </div>
           </a>
-          <a href="mailto:sascha.hurle@gmail.com" class="contact-link">
-            <span class="contact-link-icon">📬</span>
+          <div class="contact-link contact-link-plain">
+            <span class="contact-link-icon">📍</span>
             <div>
-              <span class="contact-link-label">Gmail</span>
-              <span class="contact-link-value">sascha.hurle@gmail.com</span>
+              <span class="contact-link-label">Location</span>
+              <span class="contact-link-value">Emilienstraße 29a, 20259 Hamburg</span>
             </div>
-          </a>
+          </div>
         </div>
-        <a href="mailto:sascha.hurle@diesdas.com" class="btn btn-primary btn-large">Send me a message</a>
+        <a href="mailto:sascha.hurle@gmail.com" class="btn btn-primary btn-large">Send me a message</a>
       </div>
     </div>
   </section>
@@ -346,9 +431,9 @@
     <div class="container">
       <div class="footer-inner">
         <span class="footer-logo">SH</span>
-        <span class="footer-copy">© 2024 Sascha Hurle. Built with ❤️ and curiosity.</span>
+        <span class="footer-copy">© 2024 Sascha Hurle. Hamburg, Germany.</span>
         <div class="footer-links">
-          <a href="mailto:sascha.hurle@diesdas.com">Email</a>
+          <a href="mailto:sascha.hurle@gmail.com">Email</a>
           <a href="https://twitter.com/komm_klar_" target="_blank" rel="noopener">Twitter</a>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -6,16 +6,16 @@
 }
 
 :root {
-  --bg: #0a0a0f;
-  --bg-alt: #0f0f18;
-  --bg-card: #14141f;
-  --border: rgba(255,255,255,0.07);
-  --border-hover: rgba(255,255,255,0.15);
-  --text: #f0f0f8;
-  --text-muted: #8888aa;
-  --accent: #6366f1;
-  --accent-2: #a78bfa;
-  --accent-glow: rgba(99,102,241,0.25);
+  --bg: #0e0c0a;
+  --bg-alt: #131108;
+  --bg-card: #1a1710;
+  --border: rgba(255,235,180,0.07);
+  --border-hover: rgba(255,235,180,0.18);
+  --text: #f4efe6;
+  --text-muted: #9e9076;
+  --accent: #c8a84a;
+  --accent-2: #e2c97e;
+  --accent-glow: rgba(200,168,74,0.25);
   --font-sans: 'Inter', system-ui, sans-serif;
   --font-display: 'Space Grotesk', system-ui, sans-serif;
   --radius: 12px;
@@ -332,7 +332,7 @@ em {
 .hero-blob-1 {
   width: 600px;
   height: 600px;
-  background: radial-gradient(circle, #6366f1, #a78bfa);
+  background: radial-gradient(circle, #c8a84a, #7a5e1a);
   top: -100px;
   right: -100px;
   animation: blobFloat 8s ease-in-out infinite;
@@ -341,7 +341,7 @@ em {
 .hero-blob-2 {
   width: 400px;
   height: 400px;
-  background: radial-gradient(circle, #ec4899, #6366f1);
+  background: radial-gradient(circle, #5a4010, #c8a84a);
   bottom: 0;
   left: -100px;
   animation: blobFloat 10s ease-in-out infinite reverse;
@@ -760,6 +760,115 @@ em {
   gap: 8px;
 }
 
+/* ===== Timeline list ===== */
+.timeline-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.timeline-list li {
+  padding-left: 16px;
+  position: relative;
+}
+
+.timeline-list li::before {
+  content: '→';
+  position: absolute;
+  left: 0;
+  color: var(--accent);
+  font-size: 0.85rem;
+}
+
+/* ===== Education ===== */
+.edu-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+.edu-col {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 32px;
+  transition: border-color var(--transition);
+}
+
+.edu-col:hover {
+  border-color: var(--border-hover);
+}
+
+.edu-col-title {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.edu-col-icon {
+  font-size: 1.2rem;
+}
+
+.edu-list {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.edu-item {
+  padding-bottom: 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.edu-item:last-child {
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.edu-degree {
+  font-weight: 600;
+  font-size: 0.95rem;
+  margin-bottom: 4px;
+}
+
+.edu-school {
+  font-size: 0.85rem;
+  color: var(--accent-2);
+}
+
+.edu-year {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+/* ===== Contact plain (no hover) ===== */
+.contact-link-plain {
+  cursor: default;
+}
+
+.contact-link-plain:hover {
+  transform: none;
+  border-color: var(--border);
+  background: var(--bg-card);
+}
+
+/* ===== About card location ===== */
+.card-location {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: -4px;
+}
+
 /* ===== Contact ===== */
 .contact-wrapper {
   text-align: center;
@@ -878,6 +987,9 @@ em {
   }
   .about-card {
     max-width: 400px;
+  }
+  .edu-grid {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
- Updated all content from CV image: real profile text, 3 correct jobs (financial.com, SWR, TeraVolt) with real bullet points and dates
- Added Education section (M.A. FH, B.Sc. LMU Munich)
- Added Certificates section (CSPO, Frontend Bootcamp, PM Leadership)
- Updated skills to match CV (Product Strategy, Jira/Confluence, Figma, AI Tooling, Trading Platforms)
- Added real contact details (phone, Hamburg address)
- Updated stats to 8+ years, 12+ engineers led
- Matched color palette to CV: warm dark background + golden ochre accents (#c8a84a)

https://claude.ai/code/session_01Vp6uwJWj2eTp575YgTxwZr