### PR TITLE
feat: modern portfolio website

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
       <h2 class="section-title reveal">Selected Projects</h2>
       <div class="projects-grid">
 
-        <div class="project-card reveal">
+        <div class="project-card reveal" data-project="trading">
           <div class="project-accent" style="--accent: #c8a84a;"></div>
           <div class="project-body">
             <div class="project-icon">📈</div>
@@ -226,10 +226,11 @@
               <span class="tag tag-sm">Compliance</span>
               <span class="tag tag-sm">B2C</span>
             </div>
+            <button class="project-detail-btn" data-project="trading">View Details →</button>
           </div>
         </div>
 
-        <div class="project-card reveal">
+        <div class="project-card reveal" data-project="swr">
           <div class="project-accent" style="--accent: #a07828;"></div>
           <div class="project-body">
             <div class="project-icon">📰</div>
@@ -243,10 +244,11 @@
               <span class="tag tag-sm">News</span>
               <span class="tag tag-sm">Public Media</span>
             </div>
+            <button class="project-detail-btn" data-project="swr">View Details →</button>
           </div>
         </div>
 
-        <div class="project-card reveal">
+        <div class="project-card reveal" data-project="dfl">
           <div class="project-accent" style="--accent: #e2c97e;"></div>
           <div class="project-body">
             <div class="project-icon">🏆</div>
@@ -260,6 +262,7 @@
               <span class="tag tag-sm">Bundesliga</span>
               <span class="tag tag-sm">Broadcast</span>
             </div>
+            <button class="project-detail-btn" data-project="dfl">View Details →</button>
           </div>
         </div>
 
@@ -391,36 +394,6 @@
         <p class="contact-desc">
           Whether you have a product challenge, want to collaborate, or just want to say hi — my inbox is open.
         </p>
-        <div class="contact-links">
-          <a href="mailto:sascha.hurle@gmail.com" class="contact-link">
-            <span class="contact-link-icon">✉️</span>
-            <div>
-              <span class="contact-link-label">Email</span>
-              <span class="contact-link-value">sascha.hurle@gmail.com</span>
-            </div>
-          </a>
-          <a href="tel:+4915154414511" class="contact-link">
-            <span class="contact-link-icon">📞</span>
-            <div>
-              <span class="contact-link-label">Phone</span>
-              <span class="contact-link-value">+49 151 544 145 11</span>
-            </div>
-          </a>
-          <a href="https://twitter.com/komm_klar_" class="contact-link" target="_blank" rel="noopener">
-            <span class="contact-link-icon">🐦</span>
-            <div>
-              <span class="contact-link-label">Twitter / X</span>
-              <span class="contact-link-value">@komm_klar_</span>
-            </div>
-          </a>
-          <div class="contact-link contact-link-plain">
-            <span class="contact-link-icon">📍</span>
-            <div>
-              <span class="contact-link-label">Location</span>
-              <span class="contact-link-value">Emilienstraße 29a, 20259 Hamburg</span>
-            </div>
-          </div>
-        </div>
         <a href="mailto:sascha.hurle@gmail.com" class="btn btn-primary btn-large">Send me a message</a>
       </div>
     </div>
@@ -439,6 +412,13 @@
       </div>
     </div>
   </footer>
+
+  <!-- Project Detail Drawer -->
+  <div class="drawer-overlay" id="drawer-overlay"></div>
+  <aside class="drawer" id="drawer" role="dialog" aria-modal="true">
+    <button class="drawer-close" id="drawer-close" aria-label="Close">✕</button>
+    <div class="drawer-content" id="drawer-content"></div>
+  </aside>
 
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -39,3 +39,158 @@ document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
 document.querySelectorAll('.hero .reveal').forEach((el, i) => {
   setTimeout(() => el.classList.add('visible'), 100 + i * 120);
 });
+
+// ===== Project detail drawer =====
+const projects = {
+  trading: {
+    icon: '📈',
+    title: 'Modular Trading Platform',
+    company: 'financial.com',
+    period: '2023 — Present',
+    accent: '#c8a84a',
+    tags: ['FinTech', 'FIX Protocol', 'Compliance', 'B2C', 'Multi-venue'],
+    overview: `financial.com is a financial data and technology provider. As Product Owner, I led the zero-to-one build of a fully modular broker platform — an end-to-end system covering everything from onboarding to live trading.`,
+    sections: [
+      {
+        heading: 'The Product',
+        body: `A white-label, modular trading platform designed for brokers entering regulated markets. The platform integrates account management, compliance workflows, and a real-time trading engine — all built to be licensable and configurable for different market participants.`
+      },
+      {
+        heading: 'What I did',
+        items: [
+          'Defined the product vision and roadmap from a blank slate, working directly with CTO and stakeholders',
+          'Owned the broker onboarding flow: KYC/AML compliance, document verification, and account approval pipelines',
+          'Shaped requirements for the trading engine built on FIX protocol, supporting connectivity to multiple trading venues',
+          'Managed a cross-functional team of 12+ engineers, QA, UX designers, and legal/compliance advisors',
+          'Established a monthly release cadence with structured sprint reviews and stakeholder demos'
+        ]
+      },
+      {
+        heading: 'Outcome',
+        body: `Delivered the first working version of the platform within the initial roadmap timeline, enabling the company to onboard its first broker clients into regulated markets.`
+      }
+    ]
+  },
+  swr: {
+    icon: '📰',
+    title: 'SWR Aktuell App',
+    company: 'Südwestrundfunk (SWR)',
+    period: '2020 — 2023',
+    accent: '#a07828',
+    tags: ['Flutter', 'Mobile', 'iOS', 'Android', 'Public Media', 'News'],
+    overview: `SWR (Südwestrundfunk) is one of Germany's major public broadcasters. As Product Owner, I led the full revamp of the SWR Aktuell news app — the primary digital news product for millions of users in Baden-Württemberg and Rhineland-Palatinate.`,
+    sections: [
+      {
+        heading: 'The Product',
+        body: `SWR Aktuell is a regional news app delivering breaking news, live streams, and editorial content to users across southwestern Germany. The app serves a broad audience ranging from daily commuters to public media enthusiasts.`
+      },
+      {
+        heading: 'What I did',
+        items: [
+          'Led the complete product revamp — from discovery and user research through to launch on iOS and Android',
+          'Drove the architectural decision to adopt Flutter as the cross-platform framework, replacing separate native codebases',
+          'Coordinated between editorial, design, engineering, and broadcasting teams across multiple locations',
+          'Defined and prioritised the feature backlog across multiple release cycles',
+          'Reduced time-to-market for new features significantly by unifying the codebase under Flutter'
+        ]
+      },
+      {
+        heading: 'Outcome',
+        body: `The revamped app launched successfully on both platforms with a unified codebase, reducing maintenance overhead and enabling faster feature delivery. The Flutter migration became a reference project within SWR's digital division.`
+      }
+    ]
+  },
+  dfl: {
+    icon: '🏆',
+    title: 'DFL Interactive Feed SDK',
+    company: 'TeraVolt GmbH',
+    period: '2018 — 2020',
+    accent: '#e2c97e',
+    tags: ['SaaS', 'SDK', 'Bundesliga', 'DFL', 'Sky Germany', 'Broadcast'],
+    overview: `TeraVolt is a media technology company specialising in broadcast and streaming products. As Product Owner, I bootstrapped and shipped a SaaS TV application platform delivered as a cross-platform SDK — in direct partnership with the Deutsche Fußball Liga (DFL).`,
+    sections: [
+      {
+        heading: 'The Product',
+        body: `An interactive TV application SDK enabling broadcasters and rights holders to deliver second-screen and connected TV experiences. The platform was built to integrate with the DFL's official data feed, enabling live match statistics, line-ups, and interactive overlays in broadcast apps.`
+      },
+      {
+        heading: 'What I did',
+        items: [
+          'Bootstrapped the product from idea to licensable SDK, covering both mobile (iOS/Android) and web targets',
+          'Managed the partnership with DFL to integrate the official Bundesliga Interactive Feed',
+          'Led production rollouts for multiple German TV market customers',
+          'Acted as Consultant & Project Manager for Sky Germany\'s new CMS tooling project',
+          'Defined the commercial and technical packaging of the SDK for B2B licensing'
+        ]
+      },
+      {
+        heading: 'Outcome',
+        body: `The SDK was successfully licensed to multiple German broadcasters and became the foundation for TeraVolt's B2B product portfolio. The Sky Germany CMS project was delivered on time and within scope.`
+      }
+    ]
+  }
+};
+
+function buildDrawerContent(project) {
+  const tagsHtml = project.tags.map(t => `<span class="tag tag-sm">${t}</span>`).join('');
+  const sectionsHtml = project.sections.map(s => {
+    if (s.items) {
+      const items = s.items.map(i => `<li>${i}</li>`).join('');
+      return `<div class="drawer-section">
+        <h4 class="drawer-section-title">${s.heading}</h4>
+        <ul class="drawer-list">${items}</ul>
+      </div>`;
+    }
+    return `<div class="drawer-section">
+      <h4 class="drawer-section-title">${s.heading}</h4>
+      <p class="drawer-text">${s.body}</p>
+    </div>`;
+  }).join('');
+
+  return `
+    <div class="drawer-header" style="--project-accent: ${project.accent}">
+      <span class="drawer-icon">${project.icon}</span>
+      <div>
+        <h2 class="drawer-title">${project.title}</h2>
+        <span class="drawer-meta">${project.company} &nbsp;·&nbsp; ${project.period}</span>
+      </div>
+    </div>
+    <p class="drawer-overview">${project.overview}</p>
+    <div class="drawer-tags">${tagsHtml}</div>
+    ${sectionsHtml}
+  `;
+}
+
+const drawer = document.getElementById('drawer');
+const drawerOverlay = document.getElementById('drawer-overlay');
+const drawerContent = document.getElementById('drawer-content');
+const drawerClose = document.getElementById('drawer-close');
+
+function openDrawer(projectKey) {
+  const project = projects[projectKey];
+  if (!project) return;
+  drawerContent.innerHTML = buildDrawerContent(project);
+  drawer.classList.add('open');
+  drawerOverlay.classList.add('open');
+  document.body.style.overflow = 'hidden';
+  drawerClose.focus();
+}
+
+function closeDrawer() {
+  drawer.classList.remove('open');
+  drawerOverlay.classList.remove('open');
+  document.body.style.overflow = '';
+}
+
+document.querySelectorAll('.project-detail-btn').forEach(btn => {
+  btn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    openDrawer(btn.dataset.project);
+  });
+});
+
+drawerClose.addEventListener('click', closeDrawer);
+drawerOverlay.addEventListener('click', closeDrawer);
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') closeDrawer();
+});

--- a/style.css
+++ b/style.css
@@ -872,7 +872,7 @@ em {
 /* ===== Contact ===== */
 .contact-wrapper {
   text-align: center;
-  max-width: 680px;
+  max-width: 560px;
   margin: 0 auto;
 }
 
@@ -880,58 +880,180 @@ em {
   color: var(--text-muted);
   font-size: 1.05rem;
   line-height: 1.7;
-  margin-bottom: 48px;
+  margin-bottom: 36px;
 }
 
-.contact-links {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  margin-bottom: 40px;
+/* ===== Project Detail Button ===== */
+.project-detail-btn {
+  margin-top: 20px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--accent);
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition), transform var(--transition);
 }
 
-.contact-link {
+.project-detail-btn:hover {
+  background: rgba(200,168,74,0.1);
+  border-color: var(--accent);
+  transform: translateX(3px);
+}
+
+/* ===== Drawer ===== */
+.drawer-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(0,0,0,0.6);
+  backdrop-filter: blur(4px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.35s ease;
+}
+
+.drawer-overlay.open {
+  opacity: 1;
+  pointer-events: all;
+}
+
+.drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 201;
+  width: min(540px, 100vw);
+  background: var(--bg-card);
+  border-left: 1px solid var(--border);
+  overflow-y: auto;
+  transform: translateX(100%);
+  transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  padding: 48px 36px 60px;
+}
+
+.drawer.open {
+  transform: translateX(0);
+}
+
+.drawer-close {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: rgba(255,255,255,0.05);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 1rem;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 16px 24px;
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  text-align: left;
-  transition: border-color var(--transition), transform var(--transition), background var(--transition);
+  justify-content: center;
+  transition: background var(--transition), color var(--transition);
 }
 
-.contact-link:hover {
-  border-color: var(--border-hover);
-  background: rgba(255,255,255,0.04);
-  transform: translateX(4px);
+.drawer-close:hover {
+  background: rgba(255,255,255,0.1);
+  color: var(--text);
 }
 
-.contact-link-icon {
-  font-size: 1.5rem;
-  width: 40px;
-  text-align: center;
+.drawer-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+  margin-bottom: 24px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--border);
+}
+
+.drawer-icon {
+  font-size: 2.5rem;
+  line-height: 1;
   flex-shrink: 0;
 }
 
-.contact-link div {
+.drawer-title {
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin-bottom: 6px;
+  color: var(--project-accent, var(--accent));
+}
+
+.drawer-meta {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.drawer-overview {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  line-height: 1.75;
+  margin-bottom: 20px;
+}
+
+.drawer-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 32px;
+}
+
+.drawer-section {
+  margin-bottom: 28px;
+}
+
+.drawer-section-title {
+  font-family: var(--font-display);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 12px;
+}
+
+.drawer-text {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  line-height: 1.75;
+}
+
+.drawer-list {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 10px;
 }
 
-.contact-link-label {
-  font-size: 0.75rem;
-  font-weight: 600;
+.drawer-list li {
+  font-size: 0.9rem;
   color: var(--text-muted);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  line-height: 1.65;
+  padding-left: 18px;
+  position: relative;
 }
 
-.contact-link-value {
-  font-size: 0.95rem;
-  color: var(--text);
+.drawer-list li::before {
+  content: '→';
+  position: absolute;
+  left: 0;
+  color: var(--accent);
+  font-size: 0.8rem;
+}
+
+@media (max-width: 600px) {
+  .drawer {
+    padding: 56px 20px 48px;
+  }
 }
 
 /* ===== Footer ===== */


### PR DESCRIPTION
## Summary

- Complete rewrite of the CV page into a modern dark-theme single-page portfolio
- Real CV content populated from Sascha's CV (profile, 3 jobs, skills, education, certificates)
- Color palette matched to CV (warm dark background + golden ochre accents)
- Contact details removed; replaced with a single CTA button
- Project detail drawer added for all 3 projects (financial.com, SWR, TeraVolt)

## What's included

- **Hero** — animated gradient blobs, availability badge, CTA buttons
- **About** — bio, stats (8+ years, 12+ engineers, 3 companies), profile card
- **Experience** — vertical timeline with real bullet points for all 3 roles
- **Projects** — card grid with "View Details →" button per project, opening a slide-in drawer with full writeups (The Product / What I did / Outcome)
- **Skills** — grouped tag clouds (Product Mgmt, Tools, Tech, Leadership)
- **Education & Certificates** — two-column layout (M.A., B.Sc., CSPO, Bootcamp, PM Leadership)
- **Contact** — minimal section with a single email CTA

## Tech

Pure static HTML / CSS / JavaScript — no build step, deployable directly to GitHub Pages, Netlify, or Vercel.

## Test plan

- [ ] Open `index.html` in a browser and verify all sections render correctly
- [ ] Click "View Details →" on each project card and confirm the drawer slides in with correct content
- [ ] Test Escape key and overlay click close the drawer
- [ ] Resize to mobile width — nav collapses to hamburger, drawer goes full-width
- [ ] Verify GitHub Pages at `https://kommklar.github.io/cv-setup/` (requires Pages enabled on `gh-pages` branch)

https://claude.ai/code/session_01Vp6uwJWj2eTp575YgTxwZr