### PR TITLE
feat: light theme with warm off-white background

### DIFF
--- a/script.js
+++ b/script.js
@@ -49,8 +49,8 @@ const projects = {
     period: '2023 — Present',
     accent: '#c8a84a',
     images: [
-      { src: 'https://placehold.co/760x420/1a1710/c8a84a?text=Trading+Platform+UI', alt: 'Trading platform interface' },
-      { src: 'https://placehold.co/760x420/1a1710/c8a84a?text=Broker+Onboarding+Flow', alt: 'Broker onboarding flow' },
+      { src: 'https://placehold.co/760x420/f2ede4/9a7020?text=Trading+Platform+UI', alt: 'Trading platform interface' },
+      { src: 'https://placehold.co/760x420/f2ede4/9a7020?text=Broker+Onboarding+Flow', alt: 'Broker onboarding flow' },
     ],
     tags: ['FinTech', 'FIX Protocol', 'Compliance', 'B2C', 'Multi-venue'],
     overview: `financial.com is a financial data and technology provider. As Product Owner, I led the zero-to-one build of a fully modular broker platform — an end-to-end system covering everything from onboarding to live trading.`,
@@ -82,8 +82,8 @@ const projects = {
     period: '2020 — 2023',
     accent: '#a07828',
     images: [
-      { src: 'https://placehold.co/760x420/1a1710/a07828?text=SWR+Aktuell+Home+Screen', alt: 'SWR Aktuell home screen' },
-      { src: 'https://placehold.co/760x420/1a1710/a07828?text=SWR+Aktuell+Article+View', alt: 'SWR Aktuell article view' },
+      { src: 'https://placehold.co/760x420/f2ede4/7a5c18?text=SWR+Aktuell+Home+Screen', alt: 'SWR Aktuell home screen' },
+      { src: 'https://placehold.co/760x420/f2ede4/7a5c18?text=SWR+Aktuell+Article+View', alt: 'SWR Aktuell article view' },
     ],
     tags: ['Flutter', 'Mobile', 'iOS', 'Android', 'Public Media', 'News'],
     overview: `SWR (Südwestrundfunk) is one of Germany's major public broadcasters. As Product Owner, I led the full revamp of the SWR Aktuell news app — the primary digital news product for millions of users in Baden-Württemberg and Rhineland-Palatinate.`,
@@ -115,8 +115,8 @@ const projects = {
     period: '2018 — 2020',
     accent: '#e2c97e',
     images: [
-      { src: 'https://placehold.co/760x420/1a1710/e2c97e?text=DFL+Interactive+Feed+TV+App', alt: 'DFL Interactive Feed TV app' },
-      { src: 'https://placehold.co/760x420/1a1710/e2c97e?text=Bundesliga+Live+Stats+SDK', alt: 'Bundesliga live stats overlay' },
+      { src: 'https://placehold.co/760x420/f2ede4/9a7020?text=DFL+Interactive+Feed+TV+App', alt: 'DFL Interactive Feed TV app' },
+      { src: 'https://placehold.co/760x420/f2ede4/9a7020?text=Bundesliga+Live+Stats+SDK', alt: 'Bundesliga live stats overlay' },
     ],
     tags: ['SaaS', 'SDK', 'Bundesliga', 'DFL', 'Sky Germany', 'Broadcast'],
     overview: `TeraVolt is a media technology company specialising in broadcast and streaming products. As Product Owner, I bootstrapped and shipped a SaaS TV application platform delivered as a cross-platform SDK — in direct partnership with the Deutsche Fußball Liga (DFL).`,

--- a/style.css
+++ b/style.css
@@ -6,16 +6,16 @@
 }
 
 :root {
-  --bg: #0e0c0a;
-  --bg-alt: #131108;
-  --bg-card: #1a1710;
-  --border: rgba(255,235,180,0.07);
-  --border-hover: rgba(255,235,180,0.18);
-  --text: #f4efe6;
-  --text-muted: #9e9076;
-  --accent: #c8a84a;
-  --accent-2: #e2c97e;
-  --accent-glow: rgba(200,168,74,0.25);
+  --bg: #faf8f4;
+  --bg-alt: #f2ede4;
+  --bg-card: #ffffff;
+  --border: rgba(0,0,0,0.08);
+  --border-hover: rgba(0,0,0,0.18);
+  --text: #1c1814;
+  --text-muted: #6b5e4e;
+  --accent: #9a7020;
+  --accent-2: #c8a84a;
+  --accent-glow: rgba(154,112,32,0.18);
   --font-sans: 'Inter', system-ui, sans-serif;
   --font-display: 'Space Grotesk', system-ui, sans-serif;
   --radius: 12px;
@@ -65,7 +65,7 @@ em {
 
 /* ===== Selection ===== */
 ::selection {
-  background: rgba(99,102,241,0.3);
+  background: rgba(154,112,32,0.2);
   color: var(--text);
 }
 
@@ -81,7 +81,7 @@ em {
 }
 
 .nav.scrolled {
-  background: rgba(10, 10, 15, 0.85);
+  background: rgba(250, 248, 244, 0.92);
   backdrop-filter: blur(20px);
   box-shadow: 0 1px 0 var(--border);
 }
@@ -125,17 +125,17 @@ em {
 
 .nav-links a:hover {
   color: var(--text);
-  background: rgba(255,255,255,0.06);
+  background: rgba(0,0,0,0.05);
 }
 
 .nav-cta {
-  background: rgba(99,102,241,0.15) !important;
-  color: var(--accent-2) !important;
-  border: 1px solid rgba(99,102,241,0.3) !important;
+  background: rgba(154,112,32,0.1) !important;
+  color: var(--accent) !important;
+  border: 1px solid rgba(154,112,32,0.3) !important;
 }
 
 .nav-cta:hover {
-  background: rgba(99,102,241,0.25) !important;
+  background: rgba(154,112,32,0.18) !important;
 }
 
 .nav-toggle {
@@ -162,7 +162,7 @@ em {
   position: fixed;
   inset: 0;
   z-index: 99;
-  background: rgba(10,10,15,0.98);
+  background: rgba(250,248,244,0.98);
   backdrop-filter: blur(20px);
   display: flex;
   align-items: center;
@@ -230,7 +230,7 @@ em {
 .btn-ghost:hover {
   color: var(--text);
   border-color: var(--border-hover);
-  background: rgba(255,255,255,0.04);
+  background: rgba(0,0,0,0.04);
 }
 
 .btn-large {
@@ -245,7 +245,7 @@ em {
   font-weight: 500;
   padding: 4px 12px;
   border-radius: 100px;
-  background: rgba(255,255,255,0.06);
+  background: rgba(0,0,0,0.04);
   border: 1px solid var(--border);
   color: var(--text-muted);
   white-space: nowrap;
@@ -326,13 +326,13 @@ em {
   position: absolute;
   border-radius: 50%;
   filter: blur(80px);
-  opacity: 0.18;
+  opacity: 0.35;
 }
 
 .hero-blob-1 {
   width: 600px;
   height: 600px;
-  background: radial-gradient(circle, #c8a84a, #7a5e1a);
+  background: radial-gradient(circle, #e2c97e, #c8a84a);
   top: -100px;
   right: -100px;
   animation: blobFloat 8s ease-in-out infinite;
@@ -341,7 +341,7 @@ em {
 .hero-blob-2 {
   width: 400px;
   height: 400px;
-  background: radial-gradient(circle, #5a4010, #c8a84a);
+  background: radial-gradient(circle, #f0dfa0, #9a7020);
   bottom: 0;
   left: -100px;
   animation: blobFloat 10s ease-in-out infinite reverse;
@@ -351,8 +351,8 @@ em {
   position: absolute;
   inset: 0;
   background-image:
-    linear-gradient(rgba(255,255,255,0.025) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255,255,255,0.025) 1px, transparent 1px);
+    linear-gradient(rgba(0,0,0,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,0,0,0.04) 1px, transparent 1px);
   background-size: 60px 60px;
   mask-image: radial-gradient(ellipse 80% 80% at 50% 50%, black 30%, transparent 100%);
 }
@@ -380,9 +380,9 @@ em {
   font-weight: 500;
   padding: 6px 14px;
   border-radius: 100px;
-  border: 1px solid rgba(99,102,241,0.3);
-  background: rgba(99,102,241,0.1);
-  color: var(--accent-2);
+  border: 1px solid rgba(154,112,32,0.3);
+  background: rgba(154,112,32,0.08);
+  color: var(--accent);
   margin-bottom: 24px;
 }
 
@@ -411,7 +411,7 @@ em {
 
 .hero-name {
   display: block;
-  background: linear-gradient(135deg, #fff 30%, var(--accent-2));
+  background: linear-gradient(135deg, var(--text) 30%, var(--accent));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -637,7 +637,7 @@ em {
 
 .timeline-company {
   font-size: 0.85rem;
-  color: var(--accent-2);
+  color: var(--accent);
   font-weight: 500;
 }
 
@@ -645,7 +645,7 @@ em {
   font-size: 0.8rem;
   color: var(--text-muted);
   white-space: nowrap;
-  background: rgba(255,255,255,0.04);
+  background: rgba(0,0,0,0.04);
   padding: 4px 12px;
   border-radius: 100px;
   border: 1px solid var(--border);
@@ -684,7 +684,7 @@ em {
 .project-card:hover {
   border-color: var(--border-hover);
   transform: translateY(-6px);
-  box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+  box-shadow: 0 20px 60px rgba(0,0,0,0.1);
 }
 
 .project-accent {
@@ -842,7 +842,7 @@ em {
 
 .edu-school {
   font-size: 0.85rem;
-  color: var(--accent-2);
+  color: var(--accent);
 }
 
 .edu-year {
@@ -947,7 +947,7 @@ em {
   position: absolute;
   top: 20px;
   right: 20px;
-  background: rgba(255,255,255,0.05);
+  background: rgba(0,0,0,0.04);
   border: 1px solid var(--border);
   color: var(--text-muted);
   font-size: 1rem;
@@ -962,7 +962,7 @@ em {
 }
 
 .drawer-close:hover {
-  background: rgba(255,255,255,0.1);
+  background: rgba(0,0,0,0.08);
   color: var(--text);
 }
 


### PR DESCRIPTION
## Summary

- Full switch from dark to light theme while keeping the warm golden palette from the CV
- Every hardcoded dark color updated to its light equivalent

## Changes

- **Backgrounds**: `#0e0c0a` → warm off-white `#faf8f4` / `#f2ede4` / white cards
- **Text**: `#f4efe6` → warm dark brown `#1c1814`, muted `#6b5e4e`
- **Accent**: darkened to `#9a7020` for WCAG AA contrast on light backgrounds (was `#c8a84a` which fails on white)
- **Nav** scrolled blur: dark rgba → warm off-white rgba
- **Hero blobs**: opacity raised to 0.35, colors adjusted to warm gold tones visible on light bg
- **Hero grid**: white lines → subtle dark `rgba(0,0,0,0.04)` lines
- **Mobile menu**: dark overlay → warm off-white overlay
- **Tags, badges, buttons, drawer**: all adapted for light backgrounds
- **Placeholder images**: updated to light palette

## Test plan

- [ ] Check hero section — blobs and grid should be subtly visible on the warm background
- [ ] Verify text contrast throughout (dark brown on off-white)
- [ ] Open a project drawer and confirm it renders correctly in light theme
- [ ] Check nav blur on scroll
- [ ] Test mobile menu overlay

https://claude.ai/code/session_01Vp6uwJWj2eTp575YgTxwZr